### PR TITLE
Fix import path in EditorPage

### DIFF
--- a/pages/EditorPage.tsx
+++ b/pages/EditorPage.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { BasePageLinkConfig, PageStyle, CustomerPortalConfig, EditorTab, PreviewStep, ThemeDefinition, AdminDashboardData, MonetizationUseCase, StripeLineItem, AfterPaymentTemplate } from '../../types';
+import { BasePageLinkConfig, PageStyle, CustomerPortalConfig, EditorTab, PreviewStep, ThemeDefinition, AdminDashboardData, MonetizationUseCase, StripeLineItem, AfterPaymentTemplate } from '../types';
 import EditorPanel from '../components/editor/EditorPanel';
 import PreviewPanel from '../components/editor/PreviewPanel';
 


### PR DESCRIPTION
## Summary
- fix typo in EditorPage import path

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68702100ebf4832babfdd0e60d2f98d2